### PR TITLE
Add venture studio landing layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,203 @@
 body {
   margin: 0;
 }
+
+:root {
+  color: #0f172a;
+  background-color: #f8fafc;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  padding: 48px 16px 80px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 24px;
+  padding: 32px 28px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+}
+
+.section__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero {
+  background: linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #e2e8f0;
+  border: none;
+}
+
+.hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  font-size: 12px;
+  color: #bfdbfe;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 44px);
+  line-height: 1.1;
+}
+
+.lead {
+  font-size: 18px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.hero__highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.pill-card {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(226, 232, 240, 0.2);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.pill-card__label {
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  color: #bfdbfe;
+}
+
+.pill-card__body {
+  margin: 4px 0 0;
+  font-size: 15px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 26px;
+  color: #0f172a;
+}
+
+h3 {
+  margin: 0 0 8px;
+  font-size: 20px;
+  color: #111827;
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.list {
+  margin: 8px 0 0 18px;
+  padding: 0;
+  color: #1f2937;
+  display: grid;
+  gap: 8px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.cards--two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: #f8fafc;
+  box-shadow: inset 0 1px 0 #ffffff;
+}
+
+.card--accent {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-color: #1e293b;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.25);
+}
+
+.card--accent p {
+  color: #e2e8f0;
+}
+
+.pill-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.pill {
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.4);
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+  color: #e2e8f0;
+  text-align: center;
+}
+
+.contact {
+  border: 1px solid #0f172a;
+}
+
+.contact__card {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.contact__card p {
+  color: #e2e8f0;
+}
+
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+  color: #f8fafc;
+  font-weight: 700;
+  text-decoration: none;
+  margin-top: 12px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cta-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(59, 130, 246, 0.4);
+}
+
+@media (min-width: 768px) {
+  .page {
+    padding: 64px 24px 96px;
+  }
+
+  .section {
+    padding: 40px 36px;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,134 @@
 export default function HomePage() {
   return (
-    <main>
-      {/* Your content here */}
+    <main className="page">
+      <section className="section hero">
+        <div className="section__content">
+          <p className="eyebrow">One Ping Fan Venture Studio</p>
+          <h1>We launch durable companies with domain-driven founders.</h1>
+          <p className="lead">
+            We pair conviction in applied AI with a disciplined venture studio model—validating real
+            customer pain, co-building the first product, and spinning out teams ready to scale.
+          </p>
+          <div className="hero__highlights">
+            <article className="pill-card">
+              <p className="pill-card__label">What we do</p>
+              <p className="pill-card__body">From concept to company with founders who live the problem.</p>
+            </article>
+            <article className="pill-card">
+              <p className="pill-card__label">How we work</p>
+              <p className="pill-card__body">Hands-on validation, product sprints, and operational deployment.</p>
+            </article>
+            <article className="pill-card">
+              <p className="pill-card__label">Where we focus</p>
+              <p className="pill-card__body">Industrial workflows, frontline teams, and systems that keep cities running.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section__content">
+          <h2>Studio Overview</h2>
+          <article className="card">
+            <p>
+              We are a venture studio that builds with founders, not for them. Our team brings product,
+              engineering, and go-to-market discipline to transform domain expertise into venture-scale
+              companies.
+            </p>
+            <ul className="list">
+              <li>Founder-first partnership with shared conviction and clear milestones.</li>
+              <li>Integrated product, design, and deployment support from day one.</li>
+              <li>Capital-efficient builds that prioritize customer truth over hype.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section__content">
+          <h2>Validation → Spin-Out</h2>
+          <div className="cards">
+            <article className="card">
+              <h3>Immersion & insight</h3>
+              <p>
+                We embed with operators, shadow workflows, and map the economic levers that matter. The
+                result is a clear view of the job-to-be-done and the shortest path to measurable impact.
+              </p>
+            </article>
+            <article className="card">
+              <h3>Product proof</h3>
+              <p>
+                We co-build rapid pilots, measure adoption, and tune the experience with real users. Each
+                sprint ends with evidence on retention, willingness to pay, and operational lift.
+              </p>
+            </article>
+            <article className="card">
+              <h3>Spin-out readiness</h3>
+              <p>
+                With traction in hand, we form the company, recruit the early team, and transition the
+                product into a stand-alone venture with the right capital stack and advisory bench.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section__content">
+          <h2>Operating & Deployment</h2>
+          <div className="cards cards--two">
+            <article className="card">
+              <h3>Operational lift</h3>
+              <p>
+                We design for frontline adoption—clear onboarding, resilient automations, and safeguards
+                that keep crews productive. Every deployment is measured against uptime, speed, and safety.
+              </p>
+            </article>
+            <article className="card">
+              <h3>Go-to-market rigor</h3>
+              <p>
+                From ICP definition to playbooked pilots, we build predictable motion across sales,
+                customer success, and procurement. Transparency on unit economics keeps the path to scale
+                honest.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section__content">
+          <h2>First Product: ZenShift</h2>
+          <article className="card card--accent">
+            <h3>ZenShift unlocks resilient field operations</h3>
+            <p>
+              ZenShift synchronizes scheduling, dispatch, and live issue management for distributed teams.
+              Built with supervisors and dispatchers, it brings automation and calm to high-stakes shifts.
+            </p>
+            <div className="pill-grid">
+              <div className="pill">Real-time shift orchestration</div>
+              <div className="pill">Automated alerts & incident workflows</div>
+              <div className="pill">Deployment-ready across web & mobile</div>
+              <div className="pill">Data trails for compliance & learning</div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="section contact">
+        <div className="section__content">
+          <h2>Contact</h2>
+          <article className="card contact__card">
+            <p>
+              Building in industrial, civic, or critical infrastructure domains? We would love to hear how
+              we can accelerate your vision and bring a product to market together.
+            </p>
+            <a className="cta-button" href="mailto:hello@onepingfan.com">
+              Start a conversation
+            </a>
+          </article>
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace the landing page with venture studio messaging across hero, studio overview, validation-to-spin-out, operations, product, and contact sections
- add styling for the new layout, including cards, pills, responsive grids, and CTA button treatment

## Testing
- npm run lint *(fails: unable to download eslint/eslint-config-next from registry due to 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958066f6124832cb28816b2cda2754c)