### PR TITLE
Add ZenShift spotlight card

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/public/zenshift-wave.svg
+++ b/public/zenshift-wave.svg
@@ -1,0 +1,15 @@
+<svg width="1200" height="600" viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ZenShift gradient waves</title>
+  <desc id="desc">Smooth overlapping gradient curves representing focus and flow.</desc>
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f766e"/>
+      <stop offset="50%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="600" fill="#0b1728"/>
+  <path d="M0 360C200 300 400 480 600 420C800 360 1000 200 1200 260V600H0Z" fill="url(#grad1)" fill-opacity="0.85"/>
+  <path d="M0 420C220 520 420 340 620 420C820 500 1010 460 1200 400V600H0Z" fill="url(#grad1)" fill-opacity="0.55"/>
+  <path d="M0 500C240 480 420 580 640 560C860 540 1040 480 1200 500V600H0Z" fill="#0ea5e9" fill-opacity="0.35"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,107 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Container,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+
 export default function HomePage() {
   return (
     <main>
-      {/* Your content here */}
+      <Container
+        maxWidth="md"
+        sx={{
+          py: { xs: 6, md: 10 },
+        }}
+      >
+        <Stack spacing={3}>
+          <Typography
+            component="h1"
+            variant="h3"
+            sx={{ fontWeight: 700, color: 'text.primary' }}
+          >
+            Featured spotlight
+          </Typography>
+
+          <Card
+            elevation={4}
+            sx={{
+              overflow: 'hidden',
+              borderRadius: 3,
+              background:
+                'linear-gradient(180deg, rgba(13, 26, 45, 0.9) 0%, rgba(13, 26, 45, 0.95) 100%)',
+              color: '#e5f2ff',
+            }}
+          >
+            <CardMedia
+              component="img"
+              image="/zenshift-wave.svg"
+              alt="Stylized gradient waves illustrating ZenShift automation"
+              sx={{ height: { xs: 220, md: 280 }, objectFit: 'cover' }}
+            />
+            <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+              <Typography
+                component="h2"
+                variant="h4"
+                sx={{ fontWeight: 700, mb: 2 }}
+              >
+                ZenShift
+              </Typography>
+              <Typography variant="body1" sx={{ mb: 3, maxWidth: 720 }}>
+                ZenShift streamlines AI deployment with automated workflows,
+                observability, and governance baked in. Shift teams from
+                experimentation to reliable production launches without losing
+                speed or control.
+              </Typography>
+              <CardActions sx={{ px: 0, display: 'flex', gap: 2 }}>
+                <Button
+                  component="a"
+                  href="https://zenshift.io"
+                  target="_blank"
+                  rel="noreferrer"
+                  variant="contained"
+                  color="primary"
+                  size="large"
+                  aria-label="Explore ZenShift and see how it streamlines AI orchestration"
+                  sx={{
+                    textTransform: 'none',
+                    fontWeight: 700,
+                    px: 3,
+                    boxShadow:
+                      '0px 10px 30px rgba(34, 197, 94, 0.28), 0px 6px 12px rgba(0,0,0,0.15)',
+                  }}
+                >
+                  Explore ZenShift
+                </Button>
+                <Link
+                  href="https://zenshift.io/platform"
+                  target="_blank"
+                  rel="noreferrer"
+                  underline="always"
+                  color="inherit"
+                  sx={{
+                    fontWeight: 600,
+                    letterSpacing: 0.2,
+                    '&:focus-visible': {
+                      outline: '3px solid #a855f7',
+                      outlineOffset: '4px',
+                      borderRadius: 1,
+                    },
+                  }}
+                  aria-label="Read how the ZenShift platform keeps teams aligned"
+                >
+                  See platform details
+                </Link>
+              </CardActions>
+            </CardContent>
+          </Card>
+        </Stack>
+      </Container>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a ZenShift spotlight card with illustration, description, and clear CTA links
- introduce a themed background asset for the feature block and ensure accessible styling
- add a basic ESLint config to avoid interactive prompts when linting

## Testing
- npm run lint *(fails: ESLint missing and cannot be installed because registry access returns 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580677a0d8832cbe77feb9de98f689)